### PR TITLE
Update SF YIMBY references to YIMBY Action

### DIFF
--- a/src/zoning/zoning-description.js
+++ b/src/zoning/zoning-description.js
@@ -115,7 +115,7 @@ module.exports = function ZoningDescription (props) {
       <p>
         <strong>
           want to build more housing?{' '}
-          <a href='https://www.sfyimby.org/contribute/'>donate to sf yimby</a>.
+          <a href='https://www.yimbyaction.org/join'>donate to YIMBY Action.</a>.
         </strong>
       </p>
       <p>

--- a/static/index.html
+++ b/static/index.html
@@ -23,7 +23,7 @@
       </p>
       <p>
         want lower rents, a more welcoming city, and more green on the map?
-        <strong><a href='//sfyimby.org'>join sf yimby.</a></strong>
+        <strong><a href='//yimbyaction.org/join'>join YIMBY Action.</a></strong>
       </p>
 
       <!-- <h2 id='density'><a href='#density'>#</a> housing density</h2>


### PR DESCRIPTION
If we’re asking people to donate, we should point them to the correct
organization :)

I just updated the two donate links to point to become a YIMBY Action member.

miss you! 